### PR TITLE
Fixes carousel last "page" advancement issue

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -698,7 +698,7 @@
           minItems = vars.minItems,
           maxItems = vars.maxItems;
 
-      slider.w = slider.width();
+      slider.w = slider.width() + vars.itemMargin;
       slider.h = slide.height();
       slider.boxPadding = slide.outerWidth() - slide.width();
 
@@ -715,7 +715,7 @@
         slider.pagingCount = Math.ceil(((slider.count - slider.visible)/slider.move) + 1);
         slider.last =  slider.pagingCount - 1;
         slider.limit = (slider.pagingCount === 1) ? 0 :
-                       (vars.itemWidth > slider.w) ? ((slider.itemW + (slideMargin * 2)) * slider.count) - slider.w - slideMargin : ((slider.itemW + slideMargin) * slider.count) - slider.w - slideMargin;
+                       (vars.itemWidth > slider.w) ? ((slider.itemW + (slideMargin * 2)) * slider.count) - slider.w - slideMargin : ((slider.itemW + slideMargin) * slider.count) - slider.w;
       } else {
         slider.itemW = slider.w;
         slider.pagingCount = slider.count;


### PR DESCRIPTION
In some situations the carousel wouldn't advance on the last page unless the next button is clicked twice. Sometimes it wouldn't advanced at all. Kinda hard to explain, but here's the issue recreated: http://codepen.io/anon/pen/xEbso and fixed: http://codepen.io/anon/pen/hmjrB