### PR TITLE
Fixed a bug in the carousel when move != visible slides

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -440,7 +440,15 @@
           slider.direction = (slider.currentItem < target) ? "next" : "prev";
           master.direction = slider.direction;
 
-          if (Math.ceil((target + 1)/slider.visible) - 1 !== slider.currentSlide && target !== 0) {
+
+          var toSlide;
+          if (slider.move === slider.visible || slider.move < 1) {
+          	toSlide = Math.ceil((target + 1)/slider.visible) - 1;
+          } else {
+          	// Counting the *minimum* slide/page the target item is on.
+          	toSlide = Math.floor(1 + (target - slider.count) / slider.move);
+          }
+          if (toSlide !== slider.currentSlide && target !== 0) {
             slider.currentItem = target;
             slider.slides.removeClass(namespace + "active-slide").eq(target).addClass(namespace + "active-slide");
             target = Math.floor(target/slider.visible);

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -440,7 +440,6 @@
           slider.direction = (slider.currentItem < target) ? "next" : "prev";
           master.direction = slider.direction;
 
-
           var toSlide;
           if (slider.move === slider.visible || slider.move < 1) {
           	toSlide = Math.ceil((target + 1)/slider.visible) - 1;


### PR DESCRIPTION
In short: if slides to move != visible slides, the carousel target page is not always counted correctly.

We experienced this bug when we were implementing click listeners to the carousel items which show the clicked item in the main slider. As the slider changes the slide, it also moved the carousel to what it thought was the "correct page". The bug appeared when clicking the last image (might appear also in other cases), the carousel incorrectly slid to the previous page although it should've staid on the last page. 

In our particular case we had 4 items per page and it was moving 1 item at a time.