### PR TITLE
Bugfix: If first touch is a tap, the slider doesn't respond anymore

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -323,7 +323,7 @@
           startY,
           offset,
           cwidth,
-          dx,
+          dx = null,
           startT,
           scrolling = false;
 


### PR DESCRIPTION
If someone taps without triggering the 'touchmove' event, the dx variable was undefined instead of null. Setting this to null fixes it.