### PR TITLE
rudimentary attempt at options object support

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -804,6 +804,16 @@
       // FlexSlider: removed() Callback
       vars.removed(slider);
     }
+    // Get option hash or set options and reload
+    slider.options = function(opts) {
+      if(typeof opts != 'undefined'){
+        for (var opt in opts) {
+          vars[opt] = opts[opt];
+        }
+        slider.setup();
+      }
+      return vars;
+    }
 
     //FlexSlider: Initialize
     methods.init();
@@ -871,7 +881,7 @@
 
 
   //FlexSlider: Plugin Function
-  $.fn.flexslider = function(options) {
+  $.fn.flexslider = function(options, value) {
     if (options === undefined) options = {};
 
     if (typeof options === "object") {
@@ -896,6 +906,7 @@
         case "next": $slider.flexAnimate($slider.getTarget("next"), true); break;
         case "prev":
         case "previous": $slider.flexAnimate($slider.getTarget("prev"), true); break;
+        case "options": return $slider.options(value); break;
         default: if (typeof options === "number") $slider.flexAnimate(options, true);
       }
     }


### PR DESCRIPTION
This is probably best done leveraging the jQuery $.widget factory but thats a bit more work and i didnt want to do it if you werent keen on integrating it upstream. $.widget requires jQuery 1.8+ as well.  Im happy to rework the plugin if you'd like to move that direction though.

This patch enables you to do things like:
```javascript
$('.flexslider').flexslider('options', {maxItems: 3,minItems: 3, move: 0});
```
or
```javascript
$('.flexslider').flexslider('options', {move: 0});
```
and have them rerender the slider on the fly. not all your options seem to be supported (e.g. keyboard) but they can be fixed where necessary.

I'm really sending this across as a "how do you want to handle this type of functionality" type of issue i suppose.