### PR TITLE
Fixes item width calculation when `box-sizing`='border-box'. Fixes Issue #633

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -697,10 +697,15 @@
           slideMargin = vars.itemMargin,
           minItems = vars.minItems,
           maxItems = vars.maxItems;
+          boxSizing = slide.css('-moz-box-sizing') || slide.css('-webkit-box-sizing') || slide.css('box-sizing');
 
       slider.w = slider.width();
       slider.h = slide.height();
-      slider.boxPadding = slide.outerWidth() - slide.width();
+      if (boxSizing=='border-box') {
+        slider.boxPadding = 0;
+      } else {
+        slider.boxPadding = slide.outerWidth() - slide.width();
+      }
 
       // CAROUSEL:
       if (carousel) {

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -696,7 +696,7 @@
       var slide = slider.slides.first(),
           slideMargin = vars.itemMargin,
           minItems = vars.minItems,
-          maxItems = vars.maxItems;
+          maxItems = vars.maxItems,
           boxSizing = slide.css('-moz-box-sizing') || slide.css('-webkit-box-sizing') || slide.css('box-sizing');
 
       slider.w = slider.width();


### PR DESCRIPTION
When items use `box-sizing:border-box`, a wrong `slider.boxPadding` is calculated, resulting in a smaller width per item.
This change checks if items has this `border-box` value and sets `0` to `slider.boxPadding`. Different css prefixes are taken into account.