### PR TITLE
Fixing some bugs

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -265,7 +265,7 @@
         },
         update: function() {
           var disabledClass = namespace + 'disabled';
-          if (slider.pagingCount === 1) {
+          if (slider.pagingCount === 1 || slider.count == slider.visible + 1) {
             slider.directionNav.addClass(disabledClass);
           } else if (!vars.animationLoop) {
             if (slider.animatingTo === 0) {
@@ -420,7 +420,7 @@
             target = slider.animatingTo;
 
         switch (action) {
-          case "animate": $obj.flexAnimate(target, vars.pauseOnAction, false, true); break;
+          case "animate": $obj.flexAnimate(target, vars.pauseOnAction, false, true, true); break;
           case "play": if (!$obj.playing && !$obj.asNav) { $obj.play(); } break;
           case "pause": $obj.pause(); break;
         }
@@ -578,11 +578,11 @@
       // ASNAV:
       var last = (asNav) ? slider.pagingCount - 1 : slider.last;
       return (fromNav) ? true :
-             (asNav && slider.currentItem === slider.count - 1 && target === 0 && slider.direction === "prev") ? true :
-             (asNav && slider.currentItem === 0 && target === slider.pagingCount - 1 && slider.direction !== "next") ? false :
+             (asNav && slider.currentItem === slider.count - 1 && target === 0 && slider.direction === "next") ? false :
+             (asNav && slider.currentItem === 0 && target === slider.pagingCount - 1 && slider.direction === "prev") ? false :
              (target === slider.currentSlide && !asNav) ? false :
              (vars.animationLoop) ? true :
-             (slider.atEnd && slider.currentSlide === 0 && target === last && slider.direction !== "next") ? false :
+             (slider.atEnd && slider.currentSlide === 0 && target === last && slider.direction === "prev") ? false :
              (slider.atEnd && slider.currentSlide === last && target === 0 && slider.direction === "next") ? false :
              true;
     }


### PR DESCRIPTION
1. 2nd item of the carousel cannot get "namespace + active-slide" class
Phenomenon:
When a slider and a carousel are synchronizing, the 2nd item of the carousel cannot get "namespace + active-slide" class with operating navigation buttons of slider.

Occasion:
The "withSync" argument for "slider.flexAnimate" method is missing on line 423 in v2.1 (case "animate" in slider private method "sync" section).
The value for "withSync" argument must be "true".
So, the line must be like this.

Wrong statement:
case "animate": $obj.flexAnimate(target, vars.pauseOnAction, false, true); break;

Correct statement:
case "animate": $obj.flexAnimate(target, vars.pauseOnAction, false, true, true); break;


2. slide direction condition error
Phenomenon:
The "slider.flexAnimate" method does not work if the last item of navigation carousel specified for "target" argument.

Occasion:
Conditions of the "slider.canAdvance" method are given little thoght about "undefined" value.
So, the statements must be like this.

Wrong statements:
      return (fromNav) ? true :
             (asNav && slider.currentItem === slider.count - 1 && target === 0 && slider.direction === "prev") ? true :
             (asNav && slider.currentItem === 0 && target === slider.pagingCount - 1 && slider.direction !== "next") ? false :
             (target === slider.currentSlide && !asNav) ? false :
             (vars.animationLoop) ? true :
             (slider.atEnd && slider.currentSlide === 0 && target === last && slider.direction !== "next") ? false :
             (slider.atEnd && slider.currentSlide === last && target === 0 && slider.direction === "next") ? false :
             true;

Correct statements:
      return (fromNav) ? true :
             (asNav && slider.currentItem === slider.count - 1 && target === 0 && slider.direction === "next") ? false :
             (asNav && slider.currentItem === 0 && target === slider.pagingCount - 1 && slider.direction === "prev") ? false :
             (target === slider.currentSlide && !asNav) ? false :
             (vars.animationLoop) ? true :
             (slider.atEnd && slider.currentSlide === 0 && target === last && slider.direction === "prev") ? false :
             (slider.atEnd && slider.currentSlide === last && target === 0 && slider.direction === "next") ? false :
             true;


And I have a suggestion.
I think the condition for making the directionNav disabled must be like this (line 268).

Before:
if (slider.pagingCount === 1) {

After:
if (slider.pagingCount === 1 || slider.count == slider.visible + 1) {