### PR TITLE
Add line-height to direction nav link to prevent cutoff

### DIFF
--- a/flexslider.css
+++ b/flexslider.css
@@ -68,7 +68,7 @@ html[xmlns] .slides {display: block;}
 .flexslider:hover .flex-next { opacity: 0.7; right: 10px; }
 .flexslider:hover .flex-next:hover, .flexslider:hover .flex-prev:hover { opacity: 1; }
 .flex-direction-nav .flex-disabled { opacity: 0!important; filter:alpha(opacity=0); cursor: default; }
-.flex-direction-nav a:before  { font-family: "flexslider-icon"; font-size: 40px; display: inline-block; content: '\f001'; }
+.flex-direction-nav a:before  { font-family: "flexslider-icon"; font-size: 40px; line-height: 40px; display: inline-block; content: '\f001'; }
 .flex-direction-nav a.flex-next:before  { content: '\f002'; }
 
 /* Pause/Play */


### PR DESCRIPTION
The directional link's visual was being cut off at the top and the "Previous" & "Next" text was being partially shown. This change addresses that issue.