### PR TITLE
canAdvance() bug fix

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -785,10 +785,10 @@
     }
     slider.canAdvance = function(target, fromNav) {
       // ASNAV:
-      var last = (asNav) ? slider.pagingCount - 1 : slider.last;
+      var last = (asNav) ? slider.count - 1 : slider.last;
       return (fromNav) ? true :
              (asNav && slider.currentItem === slider.count - 1 && target === 0 && slider.direction === "prev") ? true :
-             (asNav && slider.currentItem === 0 && target === slider.pagingCount - 1 && slider.direction !== "next") ? false :
+             (asNav && slider.currentItem === 0 && target === slider.count - 1 && slider.direction !== "next") ? false :
              (target === slider.currentSlide && !asNav) ? false :
              (slider.vars.animationLoop) ? true :
              (slider.atEnd && slider.currentSlide === 0 && target === last && slider.direction !== "next") ? false :


### PR DESCRIPTION
Bug fix for this issue: https://github.com/woothemes/FlexSlider/issues/655
Changed "slider.pagingCount" to "slider.count - 1" in order to always get right number of slides. The problem is that if not all slides are visible (in area), the slider.pagingCount contains just a number of slides that are not visible.