### PR TITLE
Fixes slides in an "asNavFor" slider navigating pages in IE10

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -175,6 +175,7 @@
                   var that = this;
                   that._gesture = new MSGesture();
                   that._gesture.target = that;
+                  that.addEventListener('click', function(e){ e.preventDefault(); });
                   that.addEventListener("MSPointerDown", function (e){
                       e.preventDefault();
                       if(e.currentTarget._gesture)


### PR DESCRIPTION
The event handlers were updated a while ago to support MSGesture,
but calling `preventDefault()` on a tap event doesn't stop the
click event, so the page was still navigating.

It's hard to tell that this is working without the fixes in #830 but it's a technically an unrelated fix.