### PR TITLE
Fix numbered nav when resizing

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -282,11 +282,13 @@
         },
         update: function(action, pos) {
           if (slider.pagingCount > 1 && action === "add") {
-            slider.controlNavScaffold.append($('<li><a>' + slider.count + '</a></li>'));
+            for ( i=slider.controlNav.length; i<pos; i++ ) {
+              slider.controlNavScaffold.append($('<li><a>' + (i+1) + '</a></li>'));
+            }
           } else if (slider.pagingCount === 1) {
             slider.controlNavScaffold.find('li').remove();
           } else {
-            slider.controlNav.eq(pos).closest('li').remove();
+            slider.controlNav.eq(pos+1).closest('li').remove();
           }
           methods.controlNav.set();
           (slider.pagingCount > 1 && slider.pagingCount !== slider.controlNav.length) ? slider.update(pos, action) : methods.controlNav.active();
@@ -954,7 +956,7 @@
       // update controlNav
       if (slider.vars.controlNav && !slider.manualControls) {
         if ((action === "add" && !carousel) || slider.pagingCount > slider.controlNav.length) {
-          methods.controlNav.update("add");
+          methods.controlNav.update("add", slider.pagingCount);
         } else if ((action === "remove" && !carousel) || slider.pagingCount < slider.controlNav.length) {
           if (carousel && slider.currentSlide > slider.last) {
             slider.currentSlide -= 1;


### PR DESCRIPTION
Set up flexslider to show numbered nav with 8 items (for example). 

If you resize between a layout that has 2 slides displayed at once (ie should have 4 nav controls), and one that has 1 slide displayed at once (ie should have 8 nav controls) then the numbered nav ends up correct.

Going from 1,2,3,4,5,6,7,8 to what should be 1,2,3,4 actually results in 1,2,3,8
Going from 1,2,3,4 to what should be 1,2,3,4,5,6,7,8, results in 1,2,3,4,8,8,8,8

The attached patch resolves this.