### PR TITLE
Allow CSS3 animations on the caption via update to jquery.flexslider.js

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -1060,7 +1060,7 @@
     video: false,                   //{NEW} Boolean: If using video in the slider, will prevent CSS3 3D Transforms to avoid graphical glitches
 
     // Primary Controls
-    controlNav: true,               //Boolean: Create navigation for paging control of each clide? Note: Leave true for manualControls usage
+    controlNav: true,               //Boolean: Create navigation for paging control of each slide? Note: Leave true for manualControls usage
     directionNav: true,             //Boolean: Create navigation for previous/next navigation? (true/false)
     prevText: "Previous",           //String: Set the text for the "previous" directionNav item
     nextText: "Next",               //String: Set the text for the "next" directionNav item

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -738,6 +738,9 @@
         // SMOOTH HEIGHT:
         if (slider.vars.smoothHeight) methods.smoothHeight(slider.vars.animationSpeed);
       }
+      // ALLOW CAPTION CSS3 ANIMATION:
+      var caption = $( ".flex-active-slide .flex-caption" ).detach();
+      caption.appendTo(".flex-active-slide");  
     }
     slider.wrapup = function(dimension) {
       // SLIDE:


### PR DESCRIPTION
To allow CSS3 animations on the caption every time a slide is changed, I removed the caption paragraph from the DOM and reattached in. This allows users to add CSS3 animations such as slide ins directly to the caption and it ensures it will work with every slide change.

http://jsfiddle.net/fastone/u2Kfa/