### PR TITLE
Added function to suppress the click event in IE10 after a swipe gesture

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -494,9 +494,19 @@
                                     (reverse) ? (slider.last - slider.currentSlide + slider.cloneOffset) * cwidth : (slider.currentSlide + slider.cloneOffset) * cwidth;
                 }
             }
-
+            
+            // stops next click event
+            function stopNextClick(){
+              $(this).off('click',stopNextClick);
+              return false;
+            }
+            
             function onMSGestureChange(e) {
                 e.stopPropagation();
+                
+                // prevents click event on swipe
+                $(el).click(stopNextClick);
+                
                 var slider = e.target._slider;
                 if(!slider){
                     return;
@@ -550,6 +560,9 @@
                 dx = null;
                 offset = null;
                 accDx = 0;
+                
+                // remove click suppression if not fired
+                setTimeout(function(){$(el).off('click',stopNextClick);}, 10);
             }
         }
       },


### PR DESCRIPTION

If there are links on a slide, the touch events in IE propagate click events that will navigate to links when the gesture was finished. The code I added prevents the next click when onMSGestureChange is fired. So a swipe will not propagate a click but a tap gesture will still propagate a click.