### PR TITLE
Fix vertical scrolling on WP8 IE10 e.g. Lumia 920

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -467,7 +467,7 @@
               offset = null;
             }
         }else{
-            el.style.msTouchAction = "none";
+            el.style.msTouchAction = "pan-y";
             el._gesture = new MSGesture();
             el._gesture.target = el;
             el.addEventListener("MSPointerDown", onMSPointerDown, false);


### PR DESCRIPTION
Page scroll was prevented when scrolling was started on top of a slider.
`-ms-touch-action` changed to `pan-y` to permit touch-driven panning on the vertical axis.