### PR TITLE
Fixed bug #566, which caused the slider to crash in iOS

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -442,6 +442,9 @@
                   }
                   slider.setProps(offset + dx, "setTouch");
                 }
+              }else{
+                //gesture is not related to slider direction, ignore it
+                el.removeEventListener('touchmove', onTouchMove, false);
               }
             }
 


### PR DESCRIPTION
onTouchMove() now deregisters itself if touch event is not tracking in the direction of the slider.