### PR TITLE
Ensure currentSlide is treated as an integer in getTarget().

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -798,9 +798,9 @@
     slider.getTarget = function(dir) {
       slider.direction = dir;
       if (dir === "next") {
-        return (slider.currentSlide === slider.last) ? 0 : slider.currentSlide + 1;
+        return (slider.currentSlide === slider.last) ? 0 : parseInt(slider.currentSlide, 10) + 1;
       } else {
-        return (slider.currentSlide === 0) ? slider.last : slider.currentSlide - 1;
+        return (slider.currentSlide === 0) ? slider.last : parseInt(slider.currentSlide, 10) - 1;
       }
     }
 


### PR DESCRIPTION
Hello.

Discovered an issue in the `getTarget()` method, where the `currentSlide` property is sometimes treated as a string instead of an integer. This results in the return of a concatenated string instead of an integer sum, which understandably breaks stuff when passing the "next" flag.

Ex:
```
slider.currentSlide = 8
slider.getTarget('next')
// returns "81" (str), instead of 9 (int)
```

My use case was very similar to that reported in #875 (reported 2 months ago, bummer). Jumping to a slide using the `flexAnimate()` method then broke on passing `getTarget('next')` because a concatenated string was passed instead of an integer.