### PR TITLE
Call wrapup() only if a css event was triggered by the container

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -807,9 +807,9 @@
     slider.getTarget = function(dir) {
       slider.direction = dir;
       if (dir === "next") {
-        return (slider.currentSlide === slider.last) ? 0 : slider.currentSlide + 1;
+        return (slider.currentSlide === slider.last) ? slider.vars.animationLoop ? 0 : slider.currentSlide : slider.currentSlide + 1;
       } else {
-        return (slider.currentSlide === 0) ? slider.last : slider.currentSlide - 1;
+        return (slider.currentSlide === 0) ? slider.vars.animationLoop ? slider.lastSlide : slider.currentSlide : slider.currentSlide - 1;
       }
     };
 

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -720,8 +720,10 @@
               slider.currentSlide = slider.animatingTo;
             }
             slider.container.unbind("webkitTransitionEnd transitionend");
-            slider.container.bind("webkitTransitionEnd transitionend", function() {
-              slider.wrapup(dimension);
+            slider.container.bind("webkitTransitionEnd transitionend", function(event) {
+              if (event.target === slider.container[0]) {
+                slider.wrapup(dimension);
+              }
             });
           } else {
             slider.container.animate(slider.args, slider.vars.animationSpeed, slider.vars.easing, function(){


### PR DESCRIPTION
Prevents Flexslider from erroneously executing the wrapup() method when
a css transition-end event bubbles up from a child element
of a container.