### PR TITLE
Add ability to use custom direction controls ("prev" / "next")

### DIFF
--- a/demo/basic-slider-with-custom-direction-nav.html
+++ b/demo/basic-slider-with-custom-direction-nav.html
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html class="no-js" lang="en">
+<head>
+  <meta content="charset=utf-8">
+  <title>FlexSlider 2</title>
+  <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+
+  <!-- Demo CSS -->
+  <link rel="stylesheet" href="css/demo.css" type="text/css" media="screen" />
+  <link rel="stylesheet" href="../flexslider.css" type="text/css" media="screen" />
+
+  <!-- Modernizr -->
+  <script src="js/modernizr.js"></script>
+
+  <style>
+    .flexslider {
+      margin-bottom: 10px;
+    }
+
+    .flex-control-nav {
+      position: relative;
+      bottom: auto;
+    }
+
+    .custom-navigation {
+      display: table;
+      width: 100%;
+      table-layout: fixed;
+    }
+
+    .custom-navigation > * {
+      display: table-cell;
+    }
+
+    .custom-navigation > a {
+      width: 50px;
+    }
+
+    .custom-navigation .flex-next {
+      text-align: right;
+    }
+  </style>
+
+</head>
+<body class="loading">
+
+  <div id="container" class="cf">
+    <header role="navigation">
+      <a class="logo" href="http://www.woothemes.com" title="WooThemes">
+        <img src="images/logo.png" alt="WooThemes" />
+    </a>
+      <h1>FlexSlider 2</h1>
+      <h2>The best responsive slider. Period.</h2>
+      <a class="button green" href="https://github.com/woothemes/FlexSlider/zipball/master">Download Flexslider</a>
+      <h3 class="nav-header">Other Examples</h3>
+      <nav>
+        <ul>
+          <li class="active"><a href="demo">Basic Slider</a></li>
+          <li><a href="thumbnail-controlnav.html">Slider w/thumbnail controlNav pattern</a></li>
+          <li><a href="thumbnail-slider.html">Slider w/thumbnail slider</a></li>
+          <li><a href="basic-carousel.html">Basic Carousel</a></li>
+          <li><a href="carousel-min-max.html">Carousel with min and max ranges</a></li>
+          <li><a href="dynamic-carousel-min-max.html">Carousel with dynamic min/max ranges</a></li>
+          <li><a href="video.html">Video & the api (vimeo)</a></li>
+          <li><a href="video-wistia.html">Video & the api (wistia)</a></li>
+        </ul>
+      </nav>
+    </header>
+
+  <div id="main" role="main">
+
+      <section class="slider">
+        <div class="flexslider">
+          <ul class="slides">
+            <li>
+              <img src="images/kitchen_adventurer_cheesecake_brownie.jpg" />
+            </li>
+            <li>
+              <img src="images/kitchen_adventurer_lemon.jpg" />
+            </li>
+            <li>
+              <img src="images/kitchen_adventurer_donut.jpg" />
+            </li>
+            <li>
+              <img src="images/kitchen_adventurer_caramel.jpg" />
+            </li>
+          </ul>
+        </div>
+        <div class="custom-navigation">
+          <a href="#" class="flex-prev">Prev</a>
+          <div class="custom-controls-container"></div>
+          <a href="#" class="flex-next">Next</a>
+        </div>
+      </section>
+
+      <aside>
+        <div class="cf">
+          <h3>Basic Slider</h3>
+          <ul class="toggle cf">
+            <li class="js"><a href="#view-js">JS</a></li>
+            <li class="html"><a href="#view-html">HTML</a></li>
+          </ul>
+        </div>
+        <div id="view-js" class="code">
+          <pre class="brush: js; toolbar: false; gutter: false;">
+            // Can also be used with $(document).ready()
+            $(window).load(function() {
+              $('.flexslider').flexslider({
+                animation: "slide",
+                controlsContainer: $(".custom-controls-container"),
+                customDirectionNav: $(".custom-navigation a")
+              });
+            });
+          </pre>
+        </div>
+        <div id="view-html" class="code">
+          <pre class="brush: xml; toolbar: false; gutter: false;">
+            &lt;!-- Place somewhere in the &lt;body&gt; of your page -->
+            &lt;div class="flexslider">
+              &lt;ul class="slides">
+                &lt;li>
+                  &lt;img src="slide1.jpg" />
+                &lt;/li>
+                &lt;li>
+                  &lt;img src="slide2.jpg" />
+                &lt;/li>
+                &lt;li>
+                  &lt;img src="slide3.jpg" />
+                &lt;/li>
+                &lt;li>
+                  &lt;img src="slide4.jpg" />
+                &lt;/li>
+              &lt;/ul>
+            &lt;/div>
+            &lt;div class="custom-navigation">
+              &lt;a href="#" class="flex-prev">Prev&lt;/a>
+              &lt;div class="custom-controls-container">&lt;/div>
+              &lt;a href="#" class="flex-next">Next&lt;/a>
+            &lt;/div>
+          </pre>
+        </div>
+      </aside>
+    </div>
+
+  </div>
+
+  <!-- jQuery -->
+  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+  <script>window.jQuery || document.write('<script src="js/libs/jquery-1.7.min.js">\x3C/script>')</script>
+
+  <!-- FlexSlider -->
+  <script defer src="../jquery.flexslider.js"></script>
+
+  <script type="text/javascript">
+    $(function(){
+      SyntaxHighlighter.all();
+    });
+    $(window).load(function(){
+      $('.flexslider').flexslider({
+        animation: "slide",
+        controlsContainer: $(".custom-controls-container"),
+        customDirectionNav: $(".custom-navigation a"),
+        start: function(slider){
+          $('body').removeClass('loading');
+        }
+      });
+    });
+  </script>
+
+
+  <!-- Syntax Highlighter -->
+  <script type="text/javascript" src="js/shCore.js"></script>
+  <script type="text/javascript" src="js/shBrushXml.js"></script>
+  <script type="text/javascript" src="js/shBrushJScript.js"></script>
+
+  <!-- Optional FlexSlider Additions -->
+  <script src="js/jquery.easing.js"></script>
+  <script src="js/jquery.mousewheel.js"></script>
+  <script defer src="js/demo.js"></script>
+
+</body>
+</html>

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -76,6 +76,9 @@
         // MANUAL:
         if (slider.vars.manualControls !== "") slider.manualControls = $(slider.vars.manualControls).length > 0 && $(slider.vars.manualControls);
 
+        // CUSTOM DIRECTION NAV:
+        if (slider.vars.customDirectionNav !== "") slider.customDirectionNav = $(slider.vars.customDirectionNav).length === 2 && $(slider.vars.customDirectionNav);
+
         // RANDOMIZE:
         if (slider.vars.randomize) {
           slider.slides.sort(function() { return (Math.round(Math.random())-0.5); });
@@ -297,8 +300,11 @@
         setup: function() {
           var directionNavScaffold = $('<ul class="' + namespace + 'direction-nav"><li><a class="' + namespace + 'prev" href="#">' + slider.vars.prevText + '</a></li><li><a class="' + namespace + 'next" href="#">' + slider.vars.nextText + '</a></li></ul>');
 
+          // CUSTOM DIRECTION NAV:
+          if (slider.customDirectionNav) {
+            slider.directionNav = slider.customDirectionNav;
           // CONTROLSCONTAINER:
-          if (slider.controlsContainer) {
+          } else if (slider.controlsContainer) {
             $(slider.controlsContainer).append(directionNavScaffold);
             slider.directionNav = $('.' + namespace + 'direction-nav li a', slider.controlsContainer);
           } else {
@@ -1102,6 +1108,7 @@
     // Special properties
     controlsContainer: "",          //{UPDATED} jQuery Object/Selector: Declare which container the navigation elements should be appended too. Default container is the FlexSlider element. Example use would be $(".flexslider-container"). Property is ignored if given element is not found.
     manualControls: "",             //{UPDATED} jQuery Object/Selector: Declare custom control navigation. Examples would be $(".flex-control-nav li") or "#tabs-nav li img", etc. The number of elements in your controlNav should match the number of slides/tabs.
+    customDirectionNav: "",         //{NEW} jQuery Object/Selector: Custom prev / next button. Must be two jQuery elements. In order to make the events work they have to have the classes "prev" and "next" (plus namespace)
     sync: "",                       //{NEW} Selector: Mirror the actions performed on this slider with another slider. Use with care.
     asNavFor: "",                   //{NEW} Selector: Internal property exposed for turning the slider into a thumbnail navigation for another slider
 


### PR DESCRIPTION
While flexslider is indeed very "flex"ible I think 95% percent of the people are like me: they want to use it as carousel, they want to style the controls, everything else works as expected, job done.

Customizing the controls however is less streamline then it could be since the markup for the controls are generated by the plugin. I find this ok for the controlNav (the "dots") since the number of dots depend on the number of slides. For the directionNav (prev/next button) however I more often then not came up with (sometimes crazy) solution to position and style the arrows like I wanted them to have.

This PR adds the ability to pass a jQuery obj/selector during initialization, that are simply the two direction buttons (check the example).