### PR TITLE
Fix allowOneSlide

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -1111,7 +1111,7 @@
     minItems: 1,                    //{NEW} Integer: Minimum number of carousel items that should be visible. Items will resize fluidly when below this.
     maxItems: 0,                    //{NEW} Integer: Maxmimum number of carousel items that should be visible. Items will resize fluidly when above this limit.
     move: 0,                        //{NEW} Integer: Number of carousel items that should move on animation. If 0, slider will move all visible items.
-    allowOneSlide: true,           //{NEW} Boolean: Whether or not to allow a slider comprised of a single slide
+    allowOneSlide: false,           //{NEW} Boolean: Whether or not to allow a slider comprised of a single slide, the default value is unused in code and only for documentation purposes
 
     // Callback API
     start: function(){},            //Callback: function(slider) - Fires when the slider loads the first slide
@@ -1133,7 +1133,7 @@
             selector = (options.selector) ? options.selector : ".slides > li",
             $slides = $this.find(selector);
 
-      if ( ( $slides.length === 1 && options.allowOneSlide === true ) || $slides.length === 0 ) {
+      if ( ( $slides.length === 1 && options.allowOneSlide != true ) || $slides.length === 0 ) {
           $slides.fadeIn(400);
           if (options.start) options.start($this);
         } else if ($this.data('flexslider') === undefined) {


### PR DESCRIPTION
The default value of allowOneSlide isn't used because the options aren't extended until after it is checked.  Also, the values are reversed from what the name would imply.