### PR TITLE
Update jquery.flexslider.js

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -395,7 +395,6 @@
           accDx = 0;
 
         if(!msGesture){
-            el.addEventListener('touchstart', onTouchStart, false);
 
             function onTouchStart(e) {
               if (slider.animating) {
@@ -467,6 +466,8 @@
               dx = null;
               offset = null;
             }
+            
+            el.addEventListener('touchstart', onTouchStart, false);
         }else{
             el.style.msTouchAction = "none";
             el._gesture = new MSGesture();


### PR DESCRIPTION
Moved event listener to the bottom of the conditional, this fixes problems with Firefox mobile not being able to define 'onTouchStart'.