### PR TITLE
Fix for #1197 - touch on mobile breaks if tapping first slide before changing

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -721,7 +721,7 @@
               slider.animating = false;
               slider.currentSlide = slider.animatingTo;
             }
-
+            
             // Unbind previous transitionEnd events and re-bind new transitionEnd event
             slider.container.unbind("webkitTransitionEnd transitionend");
             slider.container.bind("webkitTransitionEnd transitionend", function() {

--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -387,7 +387,7 @@
           startY,
           offset,
           cwidth,
-          dx,
+          dx = null,
           startT,
           scrolling = false,
           localX = 0,
@@ -721,7 +721,7 @@
               slider.animating = false;
               slider.currentSlide = slider.animatingTo;
             }
-            
+
             // Unbind previous transitionEnd events and re-bind new transitionEnd event
             slider.container.unbind("webkitTransitionEnd transitionend");
             slider.container.bind("webkitTransitionEnd transitionend", function() {


### PR DESCRIPTION
I've changed the declaration for `dx` so it's set to `null` to begin with. This fixes the problem I raised in #1197 