### PR TITLE
currentSlide should be set in the same place for all animation types

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -697,6 +697,8 @@
           if (!slider.vars.animationLoop) slider.pause();
         }
 
+        slider.currentSlide = slider.animatingTo;
+
         // SLIDE:
         if (!fade) {
           var dimension = (vertical) ? slider.slides.filter(':first').height() : slider.computedW,
@@ -719,9 +721,8 @@
           if (slider.transitions) {
             if (!slider.vars.animationLoop || !slider.atEnd) {
               slider.animating = false;
-              slider.currentSlide = slider.animatingTo;
             }
-            
+
             // Unbind previous transitionEnd events and re-bind new transitionEnd event
             slider.container.unbind("webkitTransitionEnd transitionend");
             slider.container.bind("webkitTransitionEnd transitionend", function() {
@@ -768,7 +769,6 @@
         }
       }
       slider.animating = false;
-      slider.currentSlide = slider.animatingTo;
       // API: after() animation Callback
       slider.vars.after(slider);
     };


### PR DESCRIPTION
Problem/Motivation:

slider.currentItem can return different results depending on whether or not css animations are enabled.  This is because `slider.currentSlide = slider.animatingTo;` can either happen in `slider.flexAnimate()` or in `slider.wrapup()`

This was causing us issues using `slider.canAdvance()` (we are using https://github.com/markirby/FlexSlider-ManualDirectionControls which relies on this method).

Proposed Solutions:
`slider.currentSlide = slider.animatingTo;` should happen in the same place for all animations, regardless of their type.