### PR TITLE
Narrowing target's index() in methods.asNav

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -161,7 +161,9 @@
               slider.slides.on(eventType, function(e){
                 e.preventDefault();
                 var $slide = $(this),
-                    target = $slide.index();
+                    sliderStringSelector = (typeof(slider[0].id) !== 'undefined' && slider[0].id !== '' ) ? '#' + slider[0].id : 
+                                                                                                            '.' + slider[0].className.replace(/\s+/g, '.').replace(/\.+$/, ''),
+                    target = $slide.index(sliderStringSelector + ' ' + slider.slides.selector);
                 var posFromLeft = $slide.offset().left - $(slider).scrollLeft(); // Find position of slide relative to left of slider container
                 if( posFromLeft <= 0 && $slide.hasClass( namespace + 'active-slide' ) ) {
                   slider.flexAnimate(slider.getTarget("prev"), true);


### PR DESCRIPTION
**Use case:**
Within the Thumbnail Slider implementation, you may want to display only some of the slides – i.e. `<li>` elements – throught a customised selector property –  for instance to set up lightbox galleries of which you'll only show cover pictures in the slider.

**Bug:**
At line 164, `target` variable calls for the `index()` function, which looks for the selector among all siblings of the page, without taking into account the parent container – i.e. the container on which flexslider have been initialised (`#slider` and `#carousel` in the official Thumbnail Slider code sample). This causes a bug, fixed by the commit below.

**See Issue #1213 for more details & Fiddles**