### PR TITLE
Reset the LI inside of .slides list

### DIFF
--- a/flexslider.css
+++ b/flexslider.css
@@ -17,6 +17,7 @@
 .flex-container a:focus,
 .flexslider a:focus  {outline: none;}
 .slides,
+.slides > li,
 .flex-control-nav,
 .flex-direction-nav {margin: 0; padding: 0; list-style: none;}
 

--- a/flexslider.less
+++ b/flexslider.less
@@ -101,6 +101,7 @@
 }
 
 .slides,
+.slides > li,
 .flex-control-nav,
 .flex-direction-nav {
   


### PR DESCRIPTION
This is similar to PR #724 which is quite old and has a conflict. But you might close that PR, too if you merged mine.

Here you can see a live example of the issue: http://jsfiddle.net/1Ld53s5e/7/

Many CSS frameworks have a default margin-left value for LI tag (we use it with ZURB Foundation, in #724 the 960s framework was mentioned).

To fix the issue, you should reset the CSS for the child LI tags from each slide (but not their grandchilds, the the slides might contain HTML markup with some lists as well).

Side note: As I don't have LESS installed, I changed the LESS and the CSS file directly (without compiling the CSS from the LESS file).