### PR TITLE
Stop sliding when not visible

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -606,7 +606,7 @@
         init: function() {
           var prefixes = ['webkit','moz','ms','o'];
 
-          if ('hidden' in document) return 'hidden';
+          if ('hidden' in document) methods.pauseInvisible.visProp = 'hidden';
           for (var i = 0; i < prefixes.length; i++) {
             if ((prefixes[i] + 'Hidden') in document)
             methods.pauseInvisible.visProp = prefixes[i] + 'Hidden';


### PR DESCRIPTION
On browsers that support PageVisibility without a vendor prefix, the function is returned, and the PageVisibility event handler is never bound.

Fixes an issues/1266