### PR TITLE
replaced jQuery 1.7 on() call with standard bind()

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -158,7 +158,7 @@
           slider.currentItem = slider.currentSlide;
           slider.slides.removeClass(namespace + "active-slide").eq(slider.currentItem).addClass(namespace + "active-slide");
           if(!msGesture){
-              slider.slides.on(eventType, function(e){
+              slider.slides.bind(eventType, function(e){
                 e.preventDefault();
                 var $slide = $(this),
                     target = $slide.index();


### PR DESCRIPTION
on() is supported from [jQuery 1.7 only](https://api.jquery.com/category/version/1.7/#post-461) and FlexSlider declares jQuery 1.3+ support. Fixing this by replacing on() call with standard bind() one - which is used all over the project anyway.