### PR TITLE
Allow jQuery versions >=1.11.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,6 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "1.11.3"
+    "jquery": ">=1.11.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/woothemes/FlexSlider#readme",
   "dependencies": {
-    "jquery": "^1.11.3"
+    "jquery": ">=1.11.3"
   }
 }


### PR DESCRIPTION
The current jQuery dependency (fixed version 1.11.3) in bower.json and package.json breaks projects using jQuery 2.x ([see issue](https://github.com/woothemes/FlexSlider/issues/1344)).

This PR semantically changes the jQuery dependency to 1.11.3**+**.