### PR TITLE
demo should not get installed when installed as a dependancy with bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "demo",
   ],
   "dependencies": {
     "jquery": ">=1.11.3"


### PR DESCRIPTION
When installing Flexslider with bower, the disributed files are too broad. No need to include the demo. This patch makes bower ignore the demo.