### PR TITLE
CSS display:none; should be used on .flex-disabled

### DIFF
--- a/css/theme.less
+++ b/css/theme.less
@@ -159,9 +159,7 @@
 
   .flex-disabled { 
 
-    opacity: 0!important; 
-    filter: alpha(opacity=0); 
-    cursor: default;
+    display: none;
 
   }
 }

--- a/demo/basic-carousel.html
+++ b/demo/basic-carousel.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/basic-slider-with-caption.html
+++ b/demo/basic-slider-with-caption.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/basic-slider-with-custom-direction-nav.html
+++ b/demo/basic-slider-with-custom-direction-nav.html
@@ -3,7 +3,7 @@
 <head>
   <meta content="charset=utf-8">
   <title>FlexSlider 2</title>
-  <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/carousel-min-max.html
+++ b/demo/carousel-min-max.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
 	<link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/dynamic-carousel-min-max.html
+++ b/demo/dynamic-carousel-min-max.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/thumbnail-controlnav.html
+++ b/demo/thumbnail-controlnav.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/thumbnail-slider.html
+++ b/demo/thumbnail-slider.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/video-wistia.html
+++ b/demo/video-wistia.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/video.html
+++ b/demo/video.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/flexslider.css
+++ b/flexslider.css
@@ -164,9 +164,7 @@ html[xmlns] .flexslider .slides {
   opacity: 1;
 }
 .flex-direction-nav .flex-disabled {
-  opacity: 0!important;
-  filter: alpha(opacity=0);
-  cursor: default;
+  display: none;
 }
 .flex-pauseplay a {
   display: block;


### PR DESCRIPTION
I noticed I can not click thumbnail image. Because there is still remaining invisible navigation arrow.(please take a look following image)
This behavior confused me.
![invisible arrow](http://f.st-hatena.com/images/fotolife/r/reggaepunch/20150712/20150712031755.png?1436645883)

My opinion is display:none; should be used in this case.
