### PR TITLE
Fix separator for meta viewport

### DIFF
--- a/demo/basic-carousel.html
+++ b/demo/basic-carousel.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/basic-slider-with-caption.html
+++ b/demo/basic-slider-with-caption.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/basic-slider-with-custom-direction-nav.html
+++ b/demo/basic-slider-with-custom-direction-nav.html
@@ -3,7 +3,7 @@
 <head>
   <meta content="charset=utf-8">
   <title>FlexSlider 2</title>
-  <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/carousel-min-max.html
+++ b/demo/carousel-min-max.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
 	<link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/dynamic-carousel-min-max.html
+++ b/demo/dynamic-carousel-min-max.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/thumbnail-controlnav.html
+++ b/demo/thumbnail-controlnav.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/thumbnail-slider.html
+++ b/demo/thumbnail-slider.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/video-wistia.html
+++ b/demo/video-wistia.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />

--- a/demo/video.html
+++ b/demo/video.html
@@ -3,7 +3,7 @@
 <head>
 	<meta content="charset=utf-8">
 	<title>FlexSlider 2</title>
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
   <!-- Syntax Highlighter -->
   <link href="css/shCore.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
I noticed some warning occurred on Google Chrome console on demo pages.
![warning](http://regepan.github.io/hexo-blog/css/images/fix-separator-for-meta-viewport.png)

Correct separator is comma(,).
```html
<meta name="viewport" content="initial-scale=2.3, user-scalable=no">
```
- Above is excerpt from
https://developer.apple.com/library/ios/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html

I fixed it.