### PR TITLE
Disable text select on thumbnails

### DIFF
--- a/css/theme.less
+++ b/css/theme.less
@@ -286,10 +286,15 @@
   img {
   
     width: 100%;
-  height: auto;
+    height: auto;
     display: block; 
     opacity: .7; 
     cursor: pointer;
+    -moz-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 
     .transition();
 

--- a/flexslider.css
+++ b/flexslider.css
@@ -246,6 +246,11 @@ html[xmlns] .flexslider .slides {
   display: block;
   opacity: .7;
   cursor: pointer;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   -webkit-transition: all 1s ease;
   -moz-transition: all 1s ease;
   -ms-transition: all 1s ease;


### PR DESCRIPTION
See also your examples with thumbnails (click on a thumbnail):
http://flexslider.woothemes.com/thumbnail-controlnav.html
http://flexslider.woothemes.com/thumbnail-slider.html