### PR TITLE
Move `focused` to a higher scope for window event

### DIFF
--- a/jquery.flexslider.js
+++ b/jquery.flexslider.js
@@ -6,6 +6,8 @@
 ;
 (function ($) {
 
+  var focused = true;
+
   //FlexSlider: Object Instance
   $.flexslider = function(el, options) {
     var slider = $(el);
@@ -26,8 +28,7 @@
         carousel = (slider.vars.itemWidth > 0),
         fade = slider.vars.animation === "fade",
         asNav = slider.vars.asNavFor !== "",
-        methods = {},
-        focused = true;
+        methods = {};
 
     // Store a reference to the slider object
     $.data(el, "flexslider", slider);


### PR DESCRIPTION
This moves `focused` to a higher scope (but still not global), so the `window` blur & focus events can update the proper variable, i.e., so this code block can access it:

```javascript
  // Ensure the slider isn't focussed if the window loses focus.
  $( window ).blur( function ( e ) {
    focused = false;
  }).focus( function ( e ) {
    focused = true;
  });
```

I suppose that functionality wasn’t doing anything with the earlier setup.